### PR TITLE
Make date conform to RFC 822

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,16 @@ function addLeadingZero(num) {
   return num;
 }
 
+function getInverseOffset(timezoneOffset) {
+  const minutes = Math.abs(timezoneOffset % 60).toFixed(0).padStart(2, 0);
+  const hours = Math.abs(Math.floor(timezoneOffset / 60)).toFixed(0).padStart(2, 0);
+    //
+  // Reverse the sign
+  const modifier = timezoneOffset < 0 ? '+' : '-';
+
+  return `${modifier}${hours}${minutes}`
+}
+
 function buildRFC822Date(dateString) {
   const dayStrings = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
   const monthStrings = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
@@ -17,7 +27,7 @@ function buildRFC822Date(dateString) {
   const month = monthStrings[date.getMonth()];
   const year = date.getFullYear();
   const time = `${addLeadingZero(date.getHours())}:${addLeadingZero(date.getMinutes())}:00`;
-  const timezone = date.getTimezoneOffset() === 0 ? "GMT" : "BST";
+  const timezone = date.getTimezoneOffset() === 0 ? "GMT" : getInverseOffset(date.getTimezoneOffset());
 
   //Wed, 02 Oct 2002 13:00:00 GMT
   return `${day}, ${dayNumber} ${month} ${year} ${time} ${timezone}`;

--- a/index.js
+++ b/index.js
@@ -5,11 +5,24 @@ function addLeadingZero(num) {
   return num;
 }
 
-function getInverseOffset(timezoneOffset) {
+function getInverseOffset(date) {
+  timezoneOffset = date.getTimezoneOffset();
+  // Calculate USA timezones.
+  // Check against known offsets to avoid TZ lookup where possible.
+  const canBeUSA = [4 * 60, 5 * 60, 6 * 60, 7 * 60, 8 * 60].includes(timezoneOffset);
+  if (canBeUSA) {
+    // Note: Date-dependant and so cannot be mapped from offsets.
+    const shortZoneName = date.toLocaleTimeString('en-US',{timeZoneName:'short'});
+    // Check for RFC 822 timezones.
+    if (["EST", "EDT", "CST", "CDT", "MST", "MDT", "PST", "PDT"].includes(shortZoneName)) {
+      return shortZoneName;
+    }
+  }
+
+  // Split hours and minutes for -HHMM / +HHMM formatting
   const minutes = Math.abs(timezoneOffset % 60).toFixed(0).padStart(2, 0);
   const hours = Math.abs(Math.floor(timezoneOffset / 60)).toFixed(0).padStart(2, 0);
-    //
-  // Reverse the sign
+  // Reverse the sign to get offset from GMT/UTC
   const modifier = timezoneOffset < 0 ? '+' : '-';
 
   return `${modifier}${hours}${minutes}`
@@ -27,7 +40,7 @@ function buildRFC822Date(dateString) {
   const month = monthStrings[date.getMonth()];
   const year = date.getFullYear();
   const time = `${addLeadingZero(date.getHours())}:${addLeadingZero(date.getMinutes())}:00`;
-  const timezone = date.getTimezoneOffset() === 0 ? "GMT" : getInverseOffset(date.getTimezoneOffset());
+  const timezone = date.getTimezoneOffset() === 0 ? "GMT" : getInverseOffset(date);
 
   //Wed, 02 Oct 2002 13:00:00 GMT
   return `${day}, ${dayNumber} ${month} ${year} ${time} ${timezone}`;


### PR DESCRIPTION
Firstly, the original code assumes you are in the UK (and so either or GMT or BST). Secondly, BST is not in RFC 822.

This code uses the +/-HHMM format from RFC 822 to properly show the offset.

An attempt has been made to use the USA timezone names in RFC 822, but it may give limited benefits (depending on system configuration).